### PR TITLE
V0.1.3

### DIFF
--- a/Editor/Elements/RGEAnimationNode.cs
+++ b/Editor/Elements/RGEAnimationNode.cs
@@ -2,11 +2,11 @@ using Aarthificial.Reanimation.Cels;
 using Aarthificial.Reanimation.Nodes;
 using System.Collections;
 using System.Collections.Generic;
-using Tomatech.ReanimationGraph.RGEditor.Inspectors;
+using Tomatech.ReanimationGraph.Editor.Inspectors;
 using UnityEditor;
 using UnityEngine;
 
-namespace Tomatech.ReanimationGraph.RGEditor.Elements
+namespace Tomatech.ReanimationGraph.Editor.Elements
 {
     public class RGEAnimationNode<TNode, TCel> : RGENodeBase 
         where TCel : ICel
@@ -22,7 +22,7 @@ namespace Tomatech.ReanimationGraph.RGEditor.Elements
                 linkedNode = existingNode as TNode;
             else
                 linkedNode = ScriptableObject.CreateInstance<TNode>();
-            NodeInspector = Editor.CreateEditor(linkedNode, typeof(RGEAnimationNodeEditor));
+            NodeInspector = UnityEditor.Editor.CreateEditor(linkedNode, typeof(RGEAnimationNodeEditor));
         }
     }
 }

--- a/Editor/Elements/RGENodeBase.cs
+++ b/Editor/Elements/RGENodeBase.cs
@@ -7,13 +7,13 @@ using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Tomatech.ReanimationGraph.RGEditor.Elements
+namespace Tomatech.ReanimationGraph.Editor.Elements
 {
     public abstract class RGENodeBase : Node
     {
         public string NodeName { get; set; }
         public abstract ReanimatorNode LinkedReanimNode { get; }
-        public Editor NodeInspector { get; protected set; }
+        public UnityEditor.Editor NodeInspector { get; protected set; }
         protected Port referencePort;
         protected Port controlDriverPort;
         protected TextField nameTextField;

--- a/Editor/Elements/RGESwitchNode.cs
+++ b/Editor/Elements/RGESwitchNode.cs
@@ -1,13 +1,13 @@
 using Aarthificial.Reanimation.Nodes;
 using System.Collections;
 using System.Collections.Generic;
-using Tomatech.ReanimationGraph.RGEditor.Inspectors;
+using Tomatech.ReanimationGraph.Editor.Inspectors;
 using UnityEditor;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Tomatech.ReanimationGraph.RGEditor.Elements
+namespace Tomatech.ReanimationGraph.Editor.Elements
 {
     public class RGESwitchNode : RGENodeBase
     {
@@ -23,7 +23,7 @@ namespace Tomatech.ReanimationGraph.RGEditor.Elements
                 linkedNode = existingNode as SwitchNode;
             else
                 linkedNode = ScriptableObject.CreateInstance<SwitchNode>();
-            NodeInspector = Editor.CreateEditor(linkedNode, typeof(RGESwitchNodeEditor));
+            NodeInspector = UnityEditor.Editor.CreateEditor(linkedNode, typeof(RGESwitchNodeEditor));
             //NodeInspector = Editor.CreateEditor(linkedNode);
         }
 

--- a/Editor/Inspectors/RGEAnimationNodeEditor.cs
+++ b/Editor/Inspectors/RGEAnimationNodeEditor.cs
@@ -3,12 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Tomatech.ReanimationGraph.RGEditor.Inspectors
+namespace Tomatech.ReanimationGraph.Editor.Inspectors
 {
     public class RGEAnimationNodeEditor : AnimationNodeEditor
     {
         protected override void OnEnable()
         {
+            if (!serializedObject.targetObject)
+                return;
             AddCustomProperty("drivers");
             Cels = AddCustomProperty("cels");
         }

--- a/Editor/Inspectors/RGEGraphOverrideEditor.cs
+++ b/Editor/Inspectors/RGEGraphOverrideEditor.cs
@@ -1,0 +1,200 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Aarthificial.Reanimation.Nodes;
+
+namespace Tomatech.ReanimationGraph.Editor.Inspectors
+{
+    [CustomEditor(typeof(RGEGraphOverride))]
+    public class RGEGraphOverrideEditor : UnityEditor.Editor
+    {
+        private SerializedProperty _next;
+        private SerializedProperty _override;
+
+        private List<TerminationNode> subAssetNodes;
+        private List<TerminationNode> looseSubAssetNodes;
+
+        private void OnEnable()
+        {
+            _next = serializedObject.FindProperty("graphNode");
+            _override = serializedObject.FindProperty("overrides");
+
+            looseSubAssetNodes = new List<TerminationNode>();
+            subAssetNodes = new List<TerminationNode>();
+
+            RegeneratePairs();
+            RecountSubAssets();
+        }
+
+        void RegeneratePairs()
+        {
+            if (_next.objectReferenceValue is RGEGraphContainer graph)
+            {
+                bool changed = false;
+                List<TerminationNode> graphTerminationNodes = graph.GetTerminationNodes();
+                List<OverridePair> currentPairs = new();
+                for (int i = 0; i < _override.arraySize; i++)
+                {
+                    TerminationNode fromNode = _override.GetArrayElementAtIndex(i).FindPropertyRelative("fromNode").objectReferenceValue as TerminationNode;
+                    if (graphTerminationNodes.Contains(fromNode))
+                    {
+                        graphTerminationNodes.RemoveAll(x => x == fromNode);
+                    }
+                    else
+                    {
+                        _override.DeleteArrayElementAtIndex(i);
+                        changed = true;
+                        i--;
+                    }
+                }
+                foreach (TerminationNode node in graphTerminationNodes)
+                {
+                    int index = _override.arraySize;
+                    _override.InsertArrayElementAtIndex(index);
+                    _override.GetArrayElementAtIndex(index).FindPropertyRelative("fromNode").objectReferenceValue = node;
+                    changed = true;
+                }
+                if (changed)
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+
+        void RecountSubAssets()
+        {
+            looseSubAssetNodes.Clear();
+            subAssetNodes.Clear();
+            Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(serializedObject.targetObject));
+            foreach (Object subAsset in subAssets)
+            {
+                if (subAsset == serializedObject.targetObject)
+                    continue;
+                if (subAsset is TerminationNode subNode)
+                    looseSubAssetNodes.Add(subNode);
+            }
+
+            for (int i = 0; i < _override.arraySize; i++)
+            {
+                TerminationNode toNode = _override.GetArrayElementAtIndex(i).FindPropertyRelative("toNode").objectReferenceValue as TerminationNode;
+                if (looseSubAssetNodes.Contains(toNode))
+                {
+                    subAssetNodes.Add(toNode);
+                    looseSubAssetNodes.Remove(toNode);
+                }
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUILayout.PropertyField(_next);
+            if (EditorGUI.EndChangeCheck())
+            {
+                //serializedObject.ApplyModifiedProperties();
+                RegeneratePairs();
+            }
+
+            if (_next.objectReferenceValue && _override.arraySize>0)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Overrides");
+                for (int i = 0; i < _override.arraySize; i++)
+                {
+                    DrawNodePairField(_override.GetArrayElementAtIndex(i));
+                }
+            }
+
+            if (looseSubAssetNodes.Count>0)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Loose Sub-assets");
+
+                for (int i = 0; i < looseSubAssetNodes.Count; i++)
+                {
+                    Rect space = EditorGUILayout.GetControlRect();
+                    Rect objectRect = new(space.x, space.y, space.width - space.height, space.height);
+                    Rect removeButton = new(space.x + space.width - space.height, space.y, space.height, space.height);
+                    GUI.enabled = false;
+                    EditorGUI.ObjectField(objectRect, looseSubAssetNodes[i], typeof(TerminationNode), false);
+                    GUI.enabled = true;
+                    if (GUI.Button(removeButton, "-"))
+                    {
+                        AssetDatabase.RemoveObjectFromAsset(looseSubAssetNodes[i]);
+                        DestroyImmediate(looseSubAssetNodes[i]);
+                        AssetDatabase.SaveAssets();
+                        AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(serializedObject.targetObject));
+
+                        looseSubAssetNodes.RemoveAt(i);
+                        i--;
+                    }
+                }
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        void DrawNodePairField(SerializedProperty nodePair)
+        {
+            Rect space = EditorGUILayout.GetControlRect();
+
+            Rect leftButton = new(space.x, space.y, space.height, space.height);
+            Rect left = new(space.x + space.height, space.y, (space.width * 0.5f) - (space.height * 1.5f), space.height);
+            Rect midButton = new(space.x + (space.width * 0.5f) - (space.height * 0.5f), space.y, space.height, space.height);
+            Rect right = new(space.x + (space.width * 0.5f) + (space.height * 0.5f), space.y, (space.width * 0.5f) - (space.height * 1.5f), space.height);
+            Rect rightButton = new(space.x + space.width - space.height, space.y, space.height, space.height);
+
+            SerializedProperty fromProp = nodePair.FindPropertyRelative("fromNode");
+            SerializedProperty toProp = nodePair.FindPropertyRelative("toNode");
+
+            EditorGUI.BeginChangeCheck();
+            if (GUI.Button(leftButton, new GUIContent("=", "Match references, effectively disabling the override")))
+            {
+                toProp.objectReferenceValue = fromProp.objectReferenceValue;
+            }
+
+            GUI.enabled = false;
+            EditorGUI.ObjectField(left, fromProp.objectReferenceValue, typeof(TerminationNode), false);
+            GUI.enabled = true;
+
+            GUI.Label(midButton, "->");
+
+
+            toProp.objectReferenceValue = EditorGUI.ObjectField(right, toProp.objectReferenceValue, typeof(TerminationNode), false);
+            if (EditorGUI.EndChangeCheck())
+            {
+                RecountSubAssets();
+            }
+
+            if (subAssetNodes.Contains(toProp.objectReferenceValue as TerminationNode))
+            {
+                GUI.enabled = false;
+                GUI.Button(rightButton, new GUIContent("*", "Clone node as editable sub-object"));
+                GUI.enabled = true;
+            }
+            else if(GUI.Button(rightButton, new GUIContent("*", "Clone node as editable sub-object")))
+            {
+                if (looseSubAssetNodes.Exists(x=>x.name== "Ovr_" + fromProp.objectReferenceValue.name))
+                {
+                    toProp.objectReferenceValue = looseSubAssetNodes.Find(x => x.name == "Ovr_" + fromProp.objectReferenceValue.name);
+                    RecountSubAssets();
+                }
+                else
+                {
+                    TerminationNode newNode = CreateInstance(fromProp.objectReferenceValue.GetType()) as TerminationNode;
+                    EditorUtility.CopySerialized(fromProp.objectReferenceValue, newNode);
+                    newNode.name = "Ovr_" + fromProp.objectReferenceValue.name;
+                    AssetDatabase.AddObjectToAsset(newNode, serializedObject.targetObject);
+                    toProp.objectReferenceValue = newNode;
+                    subAssetNodes.Add(newNode);
+
+                    AssetDatabase.SaveAssets();
+                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(serializedObject.targetObject));
+                }
+            }
+        }
+    }
+}

--- a/Editor/Inspectors/RGEGraphOverrideEditor.cs.meta
+++ b/Editor/Inspectors/RGEGraphOverrideEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71a707fe9ac587e48be6fd8242341ffc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/RGESwitchNodeEditor.cs
+++ b/Editor/Inspectors/RGESwitchNodeEditor.cs
@@ -3,12 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Tomatech.ReanimationGraph.RGEditor.Inspectors
+namespace Tomatech.ReanimationGraph.Editor.Inspectors
 {
     public class RGESwitchNodeEditor : ReanimatorNodeEditor
     {
         protected void OnEnable()
         {
+            if (!serializedObject.targetObject)
+                return;
             AddCustomProperty("drivers");
         }
     }

--- a/Editor/Windows/RGEEditorWindow.cs
+++ b/Editor/Windows/RGEEditorWindow.cs
@@ -3,7 +3,7 @@ using UnityEditor.Callbacks;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace Tomatech.ReanimationGraph.RGEditor
+namespace Tomatech.ReanimationGraph.Editor
 {
     public class RGEEditorWindow : EditorWindow
     {

--- a/Editor/Windows/RGENodeInspector.cs
+++ b/Editor/Windows/RGENodeInspector.cs
@@ -5,7 +5,7 @@ using UnityEditor;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.UIElements;
-namespace Tomatech.ReanimationGraph.RGEditor
+namespace Tomatech.ReanimationGraph.Editor
 {
     public class RGENodeInspector : GraphElement
     {
@@ -54,7 +54,7 @@ namespace Tomatech.ReanimationGraph.RGEditor
             }
         }
 
-        public void SetEditor(Editor customEditor)
+        public void SetEditor(UnityEditor.Editor customEditor)
         {
             if (customEditor)
             {

--- a/Runtime/RGEGraphContainer.cs
+++ b/Runtime/RGEGraphContainer.cs
@@ -1,10 +1,10 @@
-using Aarthificial.Reanimation;
-using Aarthificial.Reanimation.Nodes;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using Aarthificial.Reanimation;
+using Aarthificial.Reanimation.Nodes;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -12,7 +12,7 @@ using UnityEditor;
 
 namespace Tomatech.ReanimationGraph
 {
-    [CreateAssetMenu(menuName = "Tomatech/Reanimator Graph", fileName = "New Reanimator Graph")]
+    [CreateAssetMenu(menuName = "Tomatech/RGE/Graph", fileName = "New Reanimator Graph")]
     public class RGEGraphContainer : ReanimatorNode
     {
         [SerializeField]
@@ -39,6 +39,11 @@ namespace Tomatech.ReanimationGraph
         public List<DriverInstanceData> DriverData => driverData;
         public string[] DriverBlackboard => driverBlackboard;
 
+        public List<TerminationNode> GetTerminationNodes()
+        {
+            return NodeData.Select(x=>x.node).Where(x=>x is TerminationNode).Cast<TerminationNode>().ToList();
+        }
+
         public void SetRootNode(ReanimatorNode rootNode)
         {
             this.rootNode = rootNode;
@@ -62,6 +67,7 @@ namespace Tomatech.ReanimationGraph
             foreach (var item in toRemove)
             {
                 AssetDatabase.RemoveObjectFromAsset(item.node);
+                DestroyImmediate(item.node);
             }
             if (toRemove.Length>0)
             {

--- a/Runtime/RGEGraphOverride.cs
+++ b/Runtime/RGEGraphOverride.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+using Aarthificial.Reanimation;
+using Aarthificial.Reanimation.Nodes;
+
+namespace Tomatech.ReanimationGraph
+{
+    [CreateAssetMenu(menuName = "Tomatech/RGE/Graph Override", fileName = "New Reanimator Graph Override")]
+    public class RGEGraphOverride : ReanimatorNode
+    {
+        [SerializeField]
+        RGEGraphContainer graphNode;
+        [SerializeField] 
+        private List<OverridePair> overrides = new();
+
+        private readonly Dictionary<TerminationNode, TerminationNode> _map = new();
+
+        private void OnEnable()
+        {
+            _map.Clear();
+            foreach (var pair in overrides)
+            {
+                if (pair.fromNode == null || pair.toNode == null) continue;
+                _map[pair.fromNode] = pair.toNode;
+            }
+        }
+
+        public override TerminationNode Resolve(IReadOnlyReanimatorState previousState, ReanimatorState nextState)
+        {
+            AddTrace(nextState);
+            var node = graphNode.Resolve(previousState, nextState);
+            if (!_map.ContainsKey(node))
+                return node;
+
+            var overrideNode = _map[node];
+#if UNITY_EDITOR
+            nextState.AddTrace(overrideNode);
+#endif
+            return overrideNode;
+        }
+    }
+}

--- a/Runtime/RGEGraphOverride.cs.meta
+++ b/Runtime/RGEGraphOverride.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b74fdb743d709f4ba395a5342ba0cf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.tomatech.reanimationgraph",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "displayName": "Reanimation Graph",
   "description": "A basic Graph View editor to generate Reanimation node trees\nTo get the Reanimation package, see https://github.com/aarthificial/reanimation",
   "unity": "2021.3",


### PR DESCRIPTION
- Added a Graph Override node. Functions like a regular Override Node, but uses graph data to add QOL improvements like auto-filling target nodes, and cloning destination nodes as sub-assets for modification
- Fixed an issue preventing nodes from saving their new position when moved while multi-selected
- Added the ability for a graph to recover most of it's data when a Unity error occurs preventing nodes from being renamed (you may need to re-connect driver instances)